### PR TITLE
fix camera roll reset undo

### DIFF
--- a/gizmos_objects/obj_move.py
+++ b/gizmos_objects/obj_move.py
@@ -581,13 +581,16 @@ class STORYTOOLS_OT_object_rotate(Operator):
             fn.key_object(self.ob, use_autokey=True)
             if self.camera:
                 if context.region_data.view_perspective == 'CAMERA':
+                    reset_camera_roll = False
                     ## in camera, reset rotation and key if necessary
                     ## release in less than 0.25 second and moved less than 5px : reset cam rotation
                     if time() - self.start_time < 0.25 and abs(self.init_mouse_x - event.mouse_x) < 5:
+                        rotation_before_reset = self.ob.rotation_euler.copy()
                         self.reset_rotation(context)
                         fn.key_object(self.ob, use_autokey=True)
-                    
-                    if self.init_mat == self.ob.matrix_world:
+                        reset_camera_roll = rotation_before_reset != self.ob.rotation_euler
+
+                    if not reset_camera_roll and self.init_mat == self.ob.matrix_world:
                         ## Avoid undo stack push if there was no moves
                         self.exit_modal(context)
                         return {'CANCELLED'}

--- a/gizmos_objects/obj_move.py
+++ b/gizmos_objects/obj_move.py
@@ -585,10 +585,12 @@ class STORYTOOLS_OT_object_rotate(Operator):
                     ## in camera, reset rotation and key if necessary
                     ## release in less than 0.25 second and moved less than 5px : reset cam rotation
                     if time() - self.start_time < 0.25 and abs(self.init_mouse_x - event.mouse_x) < 5:
-                        rotation_before_reset = self.ob.rotation_euler.copy()
+                        rotation_before_reset = self.ob.rotation_euler.to_quaternion()
                         self.reset_rotation(context)
                         fn.key_object(self.ob, use_autokey=True)
-                        reset_camera_roll = rotation_before_reset != self.ob.rotation_euler
+                        reset_angle = rotation_before_reset.rotation_difference(
+                            self.ob.rotation_euler.to_quaternion()).angle
+                        reset_camera_roll = reset_angle > 1e-6
 
                     if not reset_camera_roll and self.init_mat == self.ob.matrix_world:
                         ## Avoid undo stack push if there was no moves


### PR DESCRIPTION
## Summary

A quick click on Rotate Camera (Roll) resets the camera as expected, but the reset was missing from the undo history.
 After performing another undoable operation, undo would jump straight back to the operation before the reset.

The existing no-change check compares `matrix_world`, but the reset updates `rotation_euler`. 
This fix checks the camera rotation directly so a valid reset is not cancelled, allowing Blender to record it in the undo history.
A small angle tolerance avoids adding an unnecessary undo entry when the camera is already horizontal.

## Testing

Tested in Blender 5.1.2 and 5.2.0 LTS with Auto Keying both enabled and disabled.

- Roll the camera
- Click Rotate Camera (Roll) to reset rotation to horizontal
- Verify that the reset creates a separate `Object Rotate` entry in the Undo History
- Resetting an already horizontal camera does not add an unnecessary undo entry

## Note

Camera roll and camera roll reset use the same operator, so both appear as `Object Rotate` in the Undo History. This fix adds a separate undo entry for the reset without changing its label.